### PR TITLE
Removed 'extra' stanza

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,5 @@
         "psr-4": {
             "Bolt\\Extension\\Bobdenotter\\Archives\\": ""
         }
-    },
-
-    "extra": {
-        "bolt-assets": "assets"
     }
 }


### PR DESCRIPTION
On a bare-ish Bolt install, I can't install this extension because of a composer error: `RecursiveDirectoryIterator::__construct(/path/to/bolt/extensions/vendor/bobdenotter/archives/assets): failed to open dir: No such file or directory`. I'm somewhat confident this change will fix that.
