### PR TITLE
Replace `LEFT` with `SUBSTR`

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -59,7 +59,7 @@ class Extension extends BaseExtension
             $column = 'datepublish';
         }
 
-        $query = "SELECT LEFT($column, $length) AS year FROM $tablename GROUP BY year ORDER BY year $order;";
+        $query = "SELECT SUBSTR($column, 0, $length) AS year FROM $tablename GROUP BY year ORDER BY year $order;";
         $statement = $this->app['db']->executeQuery($query);
         $rows = $statement->fetchAll();
 


### PR DESCRIPTION
The `LEFT()` string function is MySQL-only, and resulted in an error in my
Sqlite-powered install. It seems that `SUBSTR()` is a suitable replacement that
works in both; however, Postgres appears to use `SUBSTRING()` instead, so maybe
this would better be fixed using DQL?
