### PR TITLE
Fix when setting up the widget to avoid 'Not a valid ContentType' message

### DIFF
--- a/src/ArchivesExtension.php
+++ b/src/ArchivesExtension.php
@@ -197,7 +197,7 @@ class ArchivesExtension extends SimpleExtension
                 ->setCacheDuration(0)
                 ->setCallbackArguments([
                     'type'            => $widget['type'],
-                    'contenttypeslug' => $contentTypeName,
+                    'contentTypeName' => $contentTypeName,
                     'order'           => $widget['order'],
                     'label'           => $widget['label'],
                     'column'          => $widget['column'],


### PR DESCRIPTION
Thanks for the great extension! I tried using it with the widget and kept getting "Not a valid ContentType" message (using the widget provided in the config). 
I modified one line to fix the argument name, now widget works as expected.