### PR TITLE
Fix error if there is only one record for the given period

### DIFF
--- a/src/ArchivesExtension.php
+++ b/src/ArchivesExtension.php
@@ -128,7 +128,7 @@ class ArchivesExtension extends SimpleExtension
         // allows us to keep the sorting intact, as well as skip unpublished records.
         $records = $app['storage']->getContent($contentType['slug'], ['id' => implode(' || ', $ids)]);
         
-        if (count($records) === 1) {
+        if (!is_array($records) || count($records) === 1) {
             $records = [$records];
         }
 


### PR DESCRIPTION
`$app['storage']->getContent(...)` returns an object of class `Bolt\Legacy\Content` if there is only one result for the given query. This class does not implement the Countable interface and therefore the following exeption occurs:
```
Uncaught Exception: ContextErrorException .

ContextErrorException in ArchivesExtension.php line 130:
Warning: count(): Parameter must be an array or an object that implements Countable
```

This small change fixes this bug.