### PR TITLE
Introduce twig templates for rendering lists and the widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_*
+.idea
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ archive of newsitems. This extension takes care of creating the 'list of links',
 
 To use, place the following tag in your template, where you'd like the list of links:
 
-```
+```twig
 <h3>Monthly entry archives</h3>
 <ul class='archive_list'>
     {{ monthly_archives('entries') }}
@@ -18,7 +18,7 @@ To use, place the following tag in your template, where you'd like the list of l
 
 or
 
-```
+```twig
 <h3>Yearly news archives</h3>
 <ul class='archive_list'>
     {{ yearly_archives('news', 'asc') }}
@@ -29,20 +29,37 @@ The parameter passed, is the contenttype that's used for the archives. Be sure t
 
 You can also pass the name of the column to sort on and/or the label to use. By this point, it becomes better to use named arguments for clarity.
 
-```
+```twig
 <h3>Monthly calendar</h3>
 <ul class='archive_list'>
-    {{ monthly_archives(contenttypeslug = 'entries', order = 'asc', column = 'start_date') }}
+    {{ monthly_archives(content_type_name = 'entries', order = 'asc', column = 'start_date') }}
 </ul>
 
 
 <h3>Monthly news archives</h3>
 <ul class='archive_list'>
-    {{ monthly_archives(contenttypeslug = 'entries', label = 'In the month %B of %Y.') }}
+    {{ monthly_archives(content_type_name = 'entries', label = 'In the month %B of %Y.') }}
 </ul>
 
 ```
 
-Note: In most cases you do _not_ want to set `column` in the twig tag, but rather in `app/config/extensions/archives.bobdenotter.yml`, because that way it'll automatically work on the listing pages as well. 
+Note: In most cases you do _not_ want to set `column` in the twig tag, but rather in `app/config/extensions/archives.bobdenotter.yml`, because that way it'll automatically work on the listing pages as well.
+
+
+You can also specify a twig template that is used to render the list. For instance, that is useful if you want to add a class to the list items.
+
+ ```twig
+ <h3>Monthly entry archives</h3>
+ <ul class='archive_list'>
+     {{ monthly_archives(content_type_name = 'entries', template = 'my-archive-list.twig') }}
+ </ul>
+ ```
+ 
+ In your template directory, create a file `my-archive-list.twig` that looks similar to this:
+ ```twig
+ {% for item in list %}
+     <li class="my-fancy-css-li-class"><a href="{{ item.link }}">{{ item.period }}</a></li>
+ {% endfor %}
+ ```
 
 

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -21,4 +21,5 @@ widgets:
     type: monthly
     priority: 100
     header: "Monthly archives"
+    # template: "my-archive-widget.twig" # The twig template that is used to render the widget.
 

--- a/src/ArchivesExtension.php
+++ b/src/ArchivesExtension.php
@@ -144,6 +144,9 @@ class ArchivesExtension extends SimpleExtension
             if (!isset($widget['header'])) {
                 $widget['header'] = '';
             }
+            if (!isset($widget['template'])) {
+                $widget['template'] = '';
+            }
 
             $widgetObj = new Widget();
             $widgetObj
@@ -158,6 +161,7 @@ class ArchivesExtension extends SimpleExtension
                     'label'           => $widget['label'],
                     'column'          => $widget['column'],
                     'header'          => $widget['header'],
+                    'template'        => $widget['template'],
                 ]);
 
             if (isset($widget['priority'])) {
@@ -205,7 +209,7 @@ class ArchivesExtension extends SimpleExtension
      *
      * @return \Twig_Markup
      */
-    public function widget($type, $contentTypeName, $order, $label, $column, $header, $template = 'archive-list.twig')
+    public function widget($type, $contentTypeName, $order, $label, $column, $header, $template)
     {
         try {
             $list = ($type === 'monthly') ?
@@ -215,7 +219,7 @@ class ArchivesExtension extends SimpleExtension
             return new \Twig_Markup('Not a valid ContentType', 'UTF-8');
         }
 
-        return $this->renderList($list, $header, $template);
+        return $this->renderList($list, $header, $template === '' ? 'archive-list.twig' : $template);
     }
 
 

--- a/templates/archive-list-items.twig
+++ b/templates/archive-list-items.twig
@@ -1,0 +1,3 @@
+{% for item in list %}
+    <li><a href="{{ item.link }}">{{ item.period }}</a></li>
+{% endfor %}

--- a/templates/archive-list.twig
+++ b/templates/archive-list.twig
@@ -1,0 +1,7 @@
+{% if header %}
+    <h5>{{ header }}</h5>
+{% endif %}
+
+<ul>
+    {% include 'archive-list-items.twig' %}
+</ul>


### PR DESCRIPTION
I've modified the HTML construction for the lists generated by the twig functions and the widget to use twig templates. The user can now specify the corresponding templates.

Sorry for chaos in the comparison; I've re-ordered the functions in the file so that all functionality for the lists and widgets is together.

Closes #21 